### PR TITLE
add tasks to facilitate Schema validation and report any errors

### DIFF
--- a/src/main/java/com/marklogic/developer/corb/PreBatchUpdateFileTask.java
+++ b/src/main/java/com/marklogic/developer/corb/PreBatchUpdateFileTask.java
@@ -21,12 +21,8 @@ package com.marklogic.developer.corb;
 import static com.marklogic.developer.corb.Options.EXPORT_FILE_HEADER_LINE_COUNT;
 import static com.marklogic.developer.corb.Options.EXPORT_FILE_TOP_CONTENT;
 import com.marklogic.developer.corb.util.FileUtils;
-import static com.marklogic.developer.corb.util.StringUtils.isNotEmpty;
-import static com.marklogic.developer.corb.util.StringUtils.trimToEmpty;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+
+import java.io.*;
 
 /**
  * @author Bhagat Bandlamudi, MarkLogic Corporation
@@ -43,24 +39,17 @@ public class PreBatchUpdateFileTask extends ExportBatchToFileTask {
 	}
 
 	private void deleteFileIfExists() throws IOException {
-		File batchFile = new File(exportDir, getPartFileName());
+		File batchFile = getExportFile();
         FileUtils.deleteFile(batchFile);
 	}
 
 	protected void writeTopContent() throws IOException {
 		String topContent = getTopContent();
-		topContent = trimToEmpty(topContent);
-		if (isNotEmpty(topContent)) {
-			try (BufferedOutputStream writer = new BufferedOutputStream(new FileOutputStream(new File(exportDir, getPartFileName())))) {
-				writer.write(topContent.getBytes());
-				writer.write(NEWLINE);
-				writer.flush();
-			}
-		}
+		writeToExportFile(topContent);
 	}
 
 	private void addLineCountToProps() throws IOException{
-		int ct = FileUtils.getLineCount(new File(exportDir, getPartFileName()));
+		int ct = FileUtils.getLineCount(getExportFile());
 		if (this.properties != null && ct > 0) {
 			this.properties.setProperty(EXPORT_FILE_HEADER_LINE_COUNT, String.valueOf(ct));
 		}

--- a/src/main/java/com/marklogic/developer/corb/SchemaValidateBatchToFileTask.java
+++ b/src/main/java/com/marklogic/developer/corb/SchemaValidateBatchToFileTask.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2004-2018 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * The use of the Apache License does not indicate that this project is
+ * affiliated with the Apache Software Foundation.
+ */
+package com.marklogic.developer.corb;
+
+import com.marklogic.developer.corb.util.FileUtils;
+import com.marklogic.xcc.ResultSequence;
+import com.marklogic.xcc.types.XdmItem;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import java.io.*;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static com.marklogic.developer.corb.util.XmlUtils.schemaValidate;
+import static java.util.logging.Level.INFO;
+
+/**
+ * Validate items in a ResultSequence and write any validation errors to a single file for the batch
+ */
+public class SchemaValidateBatchToFileTask extends ExportBatchToFileTask {
+
+    private static final Object SYNC_OBJ = new Object();
+    private static final Logger LOG = Logger.getLogger(SchemaValidateBatchToFileTask.class.getName());
+
+    @Override
+    protected String processResult(ResultSequence seq) throws CorbException {
+        File schemaFile = getSchemaFile();
+        File outputFile =  getExportFile();
+
+        while (seq.hasNext()) {
+            XdmItem item = seq.next().getItem();
+            Source source = itemAsSource(item);
+            try {
+                validateAndWriteReport(source, schemaFile, outputFile);
+            } catch (IOException | SAXException | XMLStreamException ex) {
+                throw new CorbException("Unable to validate or write report for URIs: " + urisAsString(inputUris), ex);
+            }
+        }
+        return TRUE;
+    }
+
+    /**
+     * Perform XML Schema validation and write any validation errors to the outputFile
+     * @param source
+     * @param schemaFile
+     * @param outputFile
+     * @throws CorbException
+     */
+    protected void validateAndWriteReport(Source source, File schemaFile, File outputFile) throws IOException, SAXException, XMLStreamException {
+        List<SAXParseException> exceptions = schemaValidate(source, schemaFile);
+        writeSchemaValidationReport(exceptions, outputFile);
+    }
+
+    protected void writeSchemaValidationReport(List<SAXParseException> exceptions, File outputFile) throws IOException, XMLStreamException {
+        try (Writer writer = new FileWriter(outputFile, true)) {
+            writeSchemaValidationReport(exceptions, writer);
+        }
+    }
+
+    /**
+     * Serialize any SAXParseExceptions to XML for the inputUris that have been validated.
+     * @param exceptions
+     * @param writer
+     * @throws XMLStreamException
+     */
+    protected void writeSchemaValidationReport(List<SAXParseException> exceptions, Writer writer) throws XMLStreamException {
+        if (exceptions.isEmpty()) {
+            LOG.log(INFO, urisAsString(inputUris) + " is Schema valid, no errors to report");
+            return;
+        }
+
+        XMLOutputFactory output = XMLOutputFactory.newInstance();
+        synchronized (SYNC_OBJ) {
+            XMLStreamWriter xmlWriter = output.createXMLStreamWriter(writer);
+            xmlWriter.writeStartElement("document");
+            xmlWriter.writeAttribute("uri", urisAsString(inputUris));
+            for (SAXParseException exception : exceptions) {
+                writeParseException(exception, xmlWriter);
+            }
+            xmlWriter.writeEndElement();
+            xmlWriter.writeCharacters("\n");
+            xmlWriter.close();
+        }
+    }
+
+    /**
+     * Serialize a SAXParseException to XML using the XMLStreamWriter provided
+     * @param exception
+     * @param xmlWriter
+     * @throws XMLStreamException
+     */
+    protected void writeParseException(SAXParseException exception, XMLStreamWriter xmlWriter) throws XMLStreamException {
+        xmlWriter.writeStartElement("error");
+        writeAttribute(xmlWriter, "publicId", exception.getPublicId());
+        writeAttribute(xmlWriter, "systemId", exception.getSystemId());
+        writeAttribute(xmlWriter, "lineNumber", Integer.toString(exception.getLineNumber()));
+        writeAttribute(xmlWriter, "columnNumber", Integer.toString(exception.getColumnNumber()));
+        xmlWriter.writeCharacters(exception.getMessage());
+        xmlWriter.writeEndElement();
+    }
+
+    /**
+     * Write an attribute, if the provided name and value are not null, avoiding potential Null Pointer Exceptions
+     * @param writer
+     * @param name
+     * @param value
+     * @throws XMLStreamException
+     */
+    private void writeAttribute(XMLStreamWriter writer, String name, String value) throws XMLStreamException {
+        if (name != null && value != null) {
+            writer.writeAttribute(name, value);
+        }
+    }
+
+    /**
+     * Obtain a File for the configured {@value com.marklogic.developer.corb.Options#XML_SCHEMA}
+     * @return
+     */
+    protected File getSchemaFile() {
+        String schemaFilename = getProperty(Options.XML_SCHEMA);
+        return FileUtils.getFile(schemaFilename);
+    }
+
+    /**
+     * Produce a Source from XdmItem provided
+     * @param item
+     * @return
+     */
+    protected Source itemAsSource(XdmItem item) {
+        byte[] itemData = getValueAsBytes(item);
+        InputStream inputStream = new ByteArrayInputStream(itemData);
+        Source source = new StreamSource(inputStream);
+        source.setSystemId(urisAsString(inputUris));
+        return source;
+    }
+
+}

--- a/src/main/java/com/marklogic/developer/corb/SchemaValidateToFileTask.java
+++ b/src/main/java/com/marklogic/developer/corb/SchemaValidateToFileTask.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2004-2018 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * The use of the Apache License does not indicate that this project is
+ * affiliated with the Apache Software Foundation.
+ */
+package com.marklogic.developer.corb;
+
+import org.xml.sax.SAXParseException;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+
+/**
+ * Validate items in a ResultSequence and write any validation errors to an individual file per item
+ */
+public class SchemaValidateToFileTask extends SchemaValidateBatchToFileTask {
+
+    @Override
+    protected String getFileName() {
+        //this extends SchemaValidateBatchToFileTask, which produces the Batch filename instead of individual files per URI,
+        //so, need to change to a single Export file per document
+        return getExportFileName();
+    }
+
+    @Override
+    protected File getExportFile() {
+        // this extends SchemaValidateBatchToFileTask, which extends ExportBatchToFileTask and would get a File that could
+        // have the EXPORT_FILE_PART extension. We just want the regular filename.
+        return getExportFile(getFileName());
+    }
+
+    @Override
+    protected void writeSchemaValidationReport(List<SAXParseException> exceptions, File outputFile) throws IOException, XMLStreamException {
+        //Since these validation reports are per doc, the FileWriter will not append, and no need for synchnoized writes
+        try (Writer writer = new FileWriter(outputFile, false)) {
+            writeSchemaValidationReport(exceptions, writer);
+        }
+    }
+}

--- a/src/test/java/com/marklogic/developer/corb/AbstractTaskTest.java
+++ b/src/test/java/com/marklogic/developer/corb/AbstractTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * * Copyright (c) 2004-2017 MarkLogic Corporation
+ * * Copyright (c) 2004-2018 MarkLogic Corporation
  * *
  * * Licensed under the Apache License, Version 2.0 (the "License");
  * * you may not use this file except in compliance with the License.
@@ -586,6 +586,28 @@ public class AbstractTaskTest {
         fail();
     }
 
+    @Test (expected = CorbException.class)
+    public void testHandleProcessException() throws CorbException {
+        Exception ex = mock(Exception.class);
+        AbstractTask task = new AbstractTaskImpl();
+        task.handleProcessException(ex);
+    }
+
+    @Test
+    public void testHandleProcessExceptionDoNotFailOnError() {
+        String[] uris = new String[]{"foo"};
+        Exception ex = mock(Exception.class);
+        AbstractTask task = new AbstractTaskImpl();
+        task.failOnError = false;
+        task.inputUris = uris;
+        try {
+            String[] result = task.handleProcessException(ex);
+            assertArrayEquals(uris, result);
+        } catch (CorbException exc) {
+            fail();
+        }
+    }
+
     @Test
     public void testShouldRetryNotRetryableQueryExceptionCSVwithSpaces() {
         Request req = mock(Request.class);
@@ -815,26 +837,26 @@ public class AbstractTaskTest {
     }
 
     @Test
-    public void testAsString() {
+    public void testUrisAsString() {
         String[] uris = new String[]{FOO, BAR, BAZ};
         AbstractTask instance = new AbstractTaskImpl();
-        String result = instance.asString(uris);
+        String result = instance.urisAsString(uris);
         assertEquals("foo,bar,baz", result);
     }
 
     @Test
-    public void testAsStringEmptyArray() {
+    public void testUrisAsStringEmptyArray() {
         String[] uris = new String[]{};
         AbstractTask instance = new AbstractTaskImpl();
-        String result = instance.asString(uris);
+        String result = instance.urisAsString(uris);
         assertEquals("", result);
     }
 
     @Test
-    public void testAsStringNull() {
+    public void testUrisAsStringNull() {
         String[] uris = null;
         AbstractTask instance = new AbstractTaskImpl();
-        String result = instance.asString(uris);
+        String result = instance.urisAsString(uris);
         assertEquals("", result);
     }
 
@@ -947,7 +969,7 @@ public class AbstractTaskTest {
 
         boolean hasWarning = Level.WARNING.equals(records.get(0).getLevel());
         boolean shouldRetryOrFailOnErrorIsFalse = instance.shouldRetry(exception)
-                || ("failOnError is false. Encountered " + type + " at URI: " + instance.asString(uris)).equals(records.get(0).getMessage());
+                || ("failOnError is false. Encountered " + type + " at URI: " + instance.urisAsString(uris)).equals(records.get(0).getMessage());
 
         return hasWarning && shouldRetryOrFailOnErrorIsFalse;
     }

--- a/src/test/java/com/marklogic/developer/corb/ExportToFileTaskTest.java
+++ b/src/test/java/com/marklogic/developer/corb/ExportToFileTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2017 MarkLogic Corporation
+ * Copyright (c) 2004-2018 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,6 +206,14 @@ public class ExportToFileTaskTest {
             LOG.log(Level.SEVERE, null, ex);
             fail();
         }
+    }
+
+    @Test (expected = CorbException.class)
+    public void testProcessResultIOException() throws CorbException {
+        ResultSequence seq = mock(ResultSequence.class);
+        when(seq.hasNext()).thenThrow(IOException.class);
+        ExportToFileTask instance = new ExportToFileTask();
+        instance.processResult(seq);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/com/marklogic/developer/corb/SchemaValidateBatchToFileTaskTest.java
+++ b/src/test/java/com/marklogic/developer/corb/SchemaValidateBatchToFileTaskTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2004-2018 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * The use of the Apache License does not indicate that this project is
+ * affiliated with the Apache Software Foundation.
+ */
+package com.marklogic.developer.corb;
+
+import com.marklogic.developer.corb.util.FileUtils;
+import com.marklogic.xcc.ResultItem;
+import com.marklogic.xcc.ResultSequence;
+import com.marklogic.xcc.types.XdmItem;
+import org.junit.Test;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SchemaValidateBatchToFileTaskTest {
+
+    @Test
+    public void processResultValid() {
+        try {
+            String xmlFile = "src/test/resources/streamingXMLUrisLoader/EDI.ICF15T.D150217.T113100716.T";
+            String schemaFile = "src/test/resources/streamingXMLUrisLoader/BenefitEnrollment.xsd";
+            File outputFile = File.createTempFile("rpt", "xml");
+            outputFile.deleteOnExit();
+
+            SchemaValidateBatchToFileTask validateTask = createSchemaValidateTask(schemaFile, outputFile);
+            validateTask.processResult(singleFileSequence(xmlFile));
+
+            assertEquals(0, FileUtils.getLineCount(outputFile));
+
+        } catch (IOException | CorbException ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void processResultInvalid() {
+        try {
+            String xmlFile = "src/test/resources/streamingXMLUrisLoader/EDI.ICF15T.D150217.T113100716.T";
+            String schemaFile = "src/test/resources/streamingXMLUrisLoader/NotBenefitEnrollment.xsd";
+            File outputFile = File.createTempFile("rpt", "xml");
+            outputFile.deleteOnExit();
+
+            SchemaValidateBatchToFileTask validateTask = createSchemaValidateTask(schemaFile, outputFile);
+            validateTask.processResult(singleFileSequence(xmlFile));
+
+            assertNotNull(TestUtils.readFile(outputFile));
+
+        } catch (IOException | CorbException ex) {
+            fail();
+        }
+    }
+
+    @Test (expected = CorbException.class)
+    public void processResultWithException() throws CorbException {
+
+        ResultSequence sequence = mock(ResultSequence.class);
+        ResultItem resultItem = mock(ResultItem.class);
+        XdmItem xdmItem = null;
+        when(sequence.hasNext()).thenReturn(true);
+        when(sequence.next()).thenReturn(resultItem);
+        when(resultItem.getItem()).thenReturn(xdmItem);
+
+        String schemaFile = "src/test/resources/streamingXMLUrisLoader/NotBenefitEnrollment.xsd";
+        File outputFile = mock(File.class);
+        when(outputFile.getAbsolutePath()).thenReturn("/tmp/foo.xml");
+        SchemaValidateBatchToFileTask validate = createSchemaValidateTask(schemaFile, outputFile);
+
+        validate.processResult(sequence);
+    }
+
+    @Test
+    public void getSchemaFile() {
+        Properties properties = new Properties();
+        properties.setProperty(Options.XML_SCHEMA, "src/test/resources/streamingXMLUrisLoader/BenefitEnrollment.xsd");
+        SchemaValidateBatchToFileTask validate = new SchemaValidateBatchToFileTask();
+        validate.setProperties(properties);
+        File schema = validate.getSchemaFile();
+        assertTrue(schema.exists());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void getSchemaFileMissing() {
+        SchemaValidateBatchToFileTask validate = new SchemaValidateBatchToFileTask();
+        validate.getSchemaFile();
+    }
+
+    @Test
+    public void writeSchemaValidationReportWithNoExceptions() {
+        StringWriter writer = new StringWriter();
+        SchemaValidateBatchToFileTask validate = new SchemaValidateBatchToFileTask();
+        validate.inputUris = new String[]{"foo"};
+        List<SAXParseException> exceptions = new ArrayList<>();
+        try {
+            validate.writeSchemaValidationReport(exceptions, writer);
+            assertTrue(writer.toString().isEmpty());
+        } catch (XMLStreamException ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void writeParseException() {
+        Writer stringWriter = new StringWriter();
+        XMLOutputFactory output = XMLOutputFactory.newInstance();
+        SchemaValidateBatchToFileTask validate = new SchemaValidateBatchToFileTask();
+        try {
+            XMLStreamWriter xmlWriter = output.createXMLStreamWriter(stringWriter);
+            validate.writeParseException(new SAXParseException("Invalid content", "public-id", "system-id", 11, 4), xmlWriter);
+            assertEquals("<error publicId=\"public-id\" systemId=\"system-id\" lineNumber=\"11\" columnNumber=\"4\">Invalid content</error>",
+                stringWriter.toString());
+        } catch (XMLStreamException ex) {
+            fail();
+        }
+    }
+
+    public static ResultSequence singleFileSequence(String testFile) throws FileNotFoundException {
+        File file = new File(testFile);
+        return singleFileSequence(file);
+    }
+
+    public static ResultSequence singleFileSequence(File testFile) throws FileNotFoundException {
+        ResultSequence sequence = mock(ResultSequence.class);
+        ResultItem resultItem = mock(ResultItem.class);
+        XdmItem xdmItem = mock(XdmItem.class);
+
+        when(sequence.hasNext()).thenReturn(true).thenReturn(false);
+        when(resultItem.getItem()).thenReturn(xdmItem);
+        when(xdmItem.asString()).thenReturn(TestUtils.readFile(testFile));
+        when(xdmItem.asInputStream()).thenReturn(new FileInputStream(testFile));
+        when(sequence.next()).thenReturn(resultItem);
+
+        return sequence;
+    }
+
+    public static SchemaValidateBatchToFileTask createSchemaValidateTask(String schemaFileName, File outputFile ) {
+
+        Properties properties = new Properties();
+        properties.setProperty(Options.EXPORT_FILE_NAME, outputFile.getAbsolutePath());
+        properties.setProperty(Options.XML_SCHEMA, schemaFileName);
+
+        SchemaValidateBatchToFileTask validate = new SchemaValidateBatchToFileTask();
+        validate.inputUris = new String[]{"foo"};
+        validate.setProperties(properties);
+
+        return validate;
+    }
+}

--- a/src/test/java/com/marklogic/developer/corb/SchemaValidateToFileTaskTest.java
+++ b/src/test/java/com/marklogic/developer/corb/SchemaValidateToFileTaskTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2004-2018 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * The use of the Apache License does not indicate that this project is
+ * affiliated with the Apache Software Foundation.
+ */
+package com.marklogic.developer.corb;
+
+import org.junit.Test;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.stream.XMLStreamException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SchemaValidateToFileTaskTest {
+
+    @Test
+    public void testGetFileName() {
+
+        Properties properties = new Properties();
+        properties.setProperty(Options.EXPORT_FILE_NAME, "/tmp/bar.xml");
+
+        SchemaValidateToFileTask validate = new SchemaValidateToFileTask();
+        validate.setProperties(properties);
+        validate.inputUris = new String[]{"/tmp/foo.xml"};
+        String fileName = validate.getFileName();
+        assertEquals("tmp/foo.xml", fileName);
+    }
+
+    @Test
+    public void testGetExportFileDoesNotUseExportFilePartExtension() {
+        String exportFilePartExtension = ".zzz";
+        Properties properties = new Properties();
+        properties.setProperty(Options.EXPORT_FILE_NAME, "/tmp/bar.xml");
+        properties.setProperty(Options.EXPORT_FILE_PART_EXT, exportFilePartExtension);
+
+        SchemaValidateToFileTask validate = new SchemaValidateToFileTask();
+        validate.setProperties(properties);
+        validate.inputUris = new String[]{"/tmp/foo.xml"};
+
+        File exportFile = validate.getExportFile();
+        assertFalse(exportFile.getName().endsWith(exportFilePartExtension));
+        assertEquals("foo.xml", exportFile.getName());
+    }
+
+    @Test (expected = IOException.class)
+    public void testWriteSchemaValidationReportException() throws IOException, XMLStreamException {
+        List<SAXParseException> exceptions = new ArrayList<>();
+        File outputFile = mock(File.class);
+        when(outputFile.getPath()).thenThrow(IOException.class);
+        SchemaValidateToFileTask validate = new SchemaValidateToFileTask();
+        validate.writeSchemaValidationReport(exceptions, outputFile);
+    }
+
+}

--- a/src/test/java/com/marklogic/developer/corb/TestUtils.java
+++ b/src/test/java/com/marklogic/developer/corb/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2017 MarkLogic Corporation
+ * Copyright (c) 2004-2018 MarkLogic Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ public final class TestUtils {
     public static String readFile(File file) throws FileNotFoundException {
         String result;
         try ( // \A == The beginning of the input
-                Scanner scanner = new Scanner(file, "UTF-8")) {
+            Scanner scanner = new Scanner(file, "UTF-8")) {
             result = scanner.useDelimiter("\\A").next();
         }
         return result;
@@ -83,7 +83,7 @@ public final class TestUtils {
 
     public static void clearFile(File file) {
         try (PrintWriter pw = new PrintWriter(file)) {
-            //Instantiating new PRintWriter wipes the file
+            //Instantiating new PrintWriter wipes the file
         } catch (FileNotFoundException ex) {
             LOG.log(Level.SEVERE, null, ex);
         }


### PR DESCRIPTION
Added SchemaValidateBatchToFile and SchemaValidateToFile.
- If there are any validation errors, they will be written to export
file, serialized as XML with the validation error message, line and
column number in the source document.
- Refactored several methods in existing Export File classes.

Resolves issue #70