### PR TITLE
Implemented encryption support for only parts of the connection string

### DIFF
--- a/src/main/java/com/marklogic/developer/corb/AbstractManager.java
+++ b/src/main/java/com/marklogic/developer/corb/AbstractManager.java
@@ -327,7 +327,7 @@ public abstract class AbstractManager {
                     dbname = dbname.substring(1);
                 }
 
-                if(!isBlank(username) && !isBlank(password) && !isBlank(host) && !isBlank(port) && NumberUtils.toInt(port) > 0) {
+                if(!isBlank(protocol) && !isBlank(username) && !isBlank(password) && !isBlank(host) && !isBlank(port) && NumberUtils.toInt(port) > 0) {
                     username = this.decrypter.decrypt(XCC_USERNAME, username);
                     password = this.decrypter.decrypt(XCC_PASSWORD, password);
                     host = this.decrypter.decrypt(XCC_HOSTNAME, host);

--- a/src/main/java/com/marklogic/developer/corb/AbstractManager.java
+++ b/src/main/java/com/marklogic/developer/corb/AbstractManager.java
@@ -168,7 +168,7 @@ public abstract class AbstractManager {
 
     public void initPropertiesFromOptionsFile() throws IOException {
         String propsFileName = System.getProperty(OPTIONS_FILE);
-        loadPropertiesFile(propsFileName, true, this.properties);
+        loadPropertiesFile(propsFileName, true, properties);
     }
 
     public void init(String... args) throws CorbException {
@@ -192,7 +192,7 @@ public abstract class AbstractManager {
                 throw new CorbException("Failed to initialized properties from options file", ex);
             }
         } else {
-            this.properties = props;
+            properties = props;
         }
         initDecrypter();
         initSSLConfig();
@@ -214,8 +214,8 @@ public abstract class AbstractManager {
             try {
                 Class<?> decrypterCls = Class.forName(decrypterClassName);
                 if (Decrypter.class.isAssignableFrom(decrypterCls)) {
-                    this.decrypter = (Decrypter) decrypterCls.newInstance();
-                    decrypter.init(this.properties);
+                    decrypter = (Decrypter) decrypterCls.newInstance();
+                    decrypter.init(properties);
                 } else {
                     throw new IllegalArgumentException(DECRYPTER + " must be of type com.marklogic.developer.corb.Decrypter");
                 }
@@ -223,7 +223,7 @@ public abstract class AbstractManager {
                 throw new CorbException(MessageFormat.format("Unable to instantiate {0} {1}", SSL_CONFIG_CLASS, decrypterClassName), ex);
             }
         } else {
-            this.decrypter = null;
+            decrypter = null;
         }
     }
 
@@ -233,7 +233,7 @@ public abstract class AbstractManager {
             try {
                 Class<?> decrypterCls = Class.forName(sslConfigClassName);
                 if (SSLConfig.class.isAssignableFrom(decrypterCls)) {
-                    this.sslConfig = (SSLConfig) decrypterCls.newInstance();
+                    sslConfig = (SSLConfig) decrypterCls.newInstance();
                     LOG.log(INFO, () -> MessageFormat.format("Using SSLConfig {0}",decrypterCls.getName()));
                 } else {
                     throw new IllegalArgumentException("SSL Options must be of type com.marklogic.developer.corb.SSLConfig");
@@ -243,10 +243,10 @@ public abstract class AbstractManager {
             }
         } else {
             LOG.log(INFO, () -> "Using TrustAnyoneSSSLConfig because no " + SSL_CONFIG_CLASS + " value specified.");
-            this.sslConfig = new TrustAnyoneSSLConfig();
+            sslConfig = new TrustAnyoneSSLConfig();
         }
-        sslConfig.setProperties(this.properties);
-        sslConfig.setDecrypter(this.decrypter);
+        sslConfig.setProperties(properties);
+        sslConfig.setDecrypter(decrypter);
     }
 
     protected void initContentSourcePool(String uriArg) throws CorbException{
@@ -271,15 +271,15 @@ public abstract class AbstractManager {
 
         List<String> connectionUriList = new ArrayList<>();
         if (uriAsStrings == null) {
-            if (this.decrypter != null) {
-                username = this.decrypter.decrypt(XCC_USERNAME, username);
-                password = this.decrypter.decrypt(XCC_PASSWORD, password);
-                port = this.decrypter.decrypt(XCC_PORT, port);
-                dbname = !isBlank(dbname) ? this.decrypter.decrypt(XCC_DBNAME, dbname) : null;
+            if (decrypter != null) {
+                username = decrypter.decrypt(XCC_USERNAME, username);
+                password = decrypter.decrypt(XCC_PASSWORD, password);
+                port = decrypter.decrypt(XCC_PORT, port);
+                dbname = !isBlank(dbname) ? decrypter.decrypt(XCC_DBNAME, dbname) : null;
             }
             for (String host: StringUtils.commaSeparatedValuesToList(hostnames)) {
-                if (this.decrypter != null) {
-                    host = this.decrypter.decrypt(XCC_HOSTNAME, host);
+                if (decrypter != null) {
+                    host = decrypter.decrypt(XCC_HOSTNAME, host);
                 }
                 String connectionUri = StringUtils.getXccUri(protocol, username, password, host, port, dbname);
                 if (connectionUri != null) {
@@ -288,10 +288,10 @@ public abstract class AbstractManager {
             }
         } else {
             for (String connectionUri : StringUtils.commaSeparatedValuesToList(uriAsStrings)) {
-                if (this.decrypter != null) {
-                    connectionUri = this.decrypter.decrypt(XCC_CONNECTION_URI, connectionUri);
+                if (decrypter != null) {
+                    connectionUri = decrypter.decrypt(XCC_CONNECTION_URI, connectionUri);
                     //see if individual parts of the connection string are encrypted separately
-                    connectionUri = tryToDecryptUriInParts(connectionUri);                  
+                    connectionUri = tryToDecryptUriInParts(connectionUri);
                 }
                 if (connectionUri != null) {
                     connectionUriList.add(connectionUri);
@@ -299,41 +299,41 @@ public abstract class AbstractManager {
             }
         }
 
-        this.csp = createContentSourcePool();
-        LOG.info("Using the content source manager " + this.csp.getClass().getName());
-        this.csp.init(properties, sslConfig, connectionUriList.toArray(new String[connectionUriList.size()]));
+        csp = createContentSourcePool();
+        LOG.info("Using the content source manager " + csp.getClass().getName());
+        csp.init(properties, sslConfig, connectionUriList.toArray(new String[connectionUriList.size()]));
 
-        if (!this.csp.available()) {
+        if (!csp.available()) {
             throw new CorbException("No connections available. Please check connection parameters or initialization errors");
         }
     }
-    
+
     protected String tryToDecryptUriInParts(String connectionUri) {
         LOG.info("Checking if any part of the connection string are encrypted");
         String uriAfterDecrypt = connectionUri;
+        Pattern pattern = Pattern.compile(XCC_CONNECTION_URI_PATTERN);
         try {
-            Pattern pattern = Pattern.compile(XCC_CONNECTION_URI_PATTERN);
             Matcher matcher = pattern.matcher(connectionUri);
-            matcher.find();
-            if(matcher.matches() && matcher.groupCount() >= 5) {
+
+            if (matcher.matches() && matcher.groupCount() >= 5) {
                 String protocol = matcher.group(1);
                 String username = matcher.group(2);
                 String password = matcher.group(3);
                 String host = matcher.group(4);
                 String port = matcher.group(5);
-                
+
                 String dbname = matcher.groupCount() > 5 ? matcher.group(6) : null;
                 if (dbname != null && dbname.startsWith("/")) {
                     dbname = dbname.substring(1);
                 }
 
-                if(!isBlank(protocol) && !isBlank(username) && !isBlank(password) && !isBlank(host) && !isBlank(port) && NumberUtils.toInt(port) > 0) {
-                    username = this.decrypter.decrypt(XCC_USERNAME, username);
-                    password = this.decrypter.decrypt(XCC_PASSWORD, password);
-                    host = this.decrypter.decrypt(XCC_HOSTNAME, host);
-                    dbname = !isBlank(dbname) ? this.decrypter.decrypt(XCC_DBNAME, dbname) : null;
-                    uriAfterDecrypt = StringUtils.getXccUri(protocol, username, password, host, port, dbname);                    
-                }                
+                if (!isBlank(protocol) && !isBlank(username) && !isBlank(password) && !isBlank(host) && !isBlank(port) && NumberUtils.toInt(port) > 0) {
+                    username = decrypter.decrypt(XCC_USERNAME, username);
+                    password = decrypter.decrypt(XCC_PASSWORD, password);
+                    host = decrypter.decrypt(XCC_HOSTNAME, host);
+                    dbname = !isBlank(dbname) ? decrypter.decrypt(XCC_DBNAME, dbname) : null;
+                    uriAfterDecrypt = StringUtils.getXccUri(protocol, username, password, host, port, dbname);
+                }
             }
         } catch (IllegalStateException exc) {
            LOG.log(WARNING,"Unable to parse connection uri "+ exc.getMessage());
@@ -366,7 +366,7 @@ public abstract class AbstractManager {
     }
 
     public ContentSourcePool getContentSourcePool() {
-        return this.csp;
+        return csp;
     }
 
     protected void initOptions(String... args) throws CorbException {
@@ -461,8 +461,8 @@ public abstract class AbstractManager {
             retVal = argVal.trim();
         } else if (isNotBlank(System.getProperty(propertyName))) {
             retVal = System.getProperty(propertyName).trim();
-        } else if (this.properties.containsKey(propertyName) && isNotBlank(this.properties.getProperty(propertyName))) {
-            retVal = this.properties.getProperty(propertyName).trim();
+        } else if (properties.containsKey(propertyName) && isNotBlank(properties.getProperty(propertyName))) {
+            retVal = properties.getProperty(propertyName).trim();
         }
         //doesn't capture defaults, only user provided.
         String[] secureWords = {"XCC", "PASSWORD", "SSL"};
@@ -474,7 +474,7 @@ public abstract class AbstractManager {
             }
         }
         if (retVal != null && !hasSecureWords) {
-            this.userProvidedOptions.put(propertyName, retVal);
+            userProvidedOptions.put(propertyName, retVal);
         }
         return retVal;
     }

--- a/src/main/java/com/marklogic/developer/corb/AbstractManager.java
+++ b/src/main/java/com/marklogic/developer/corb/AbstractManager.java
@@ -275,16 +275,14 @@ public abstract class AbstractManager {
                 username = decrypter.decrypt(XCC_USERNAME, username);
                 password = decrypter.decrypt(XCC_PASSWORD, password);
                 port = decrypter.decrypt(XCC_PORT, port);
-                dbname = !isBlank(dbname) ? decrypter.decrypt(XCC_DBNAME, dbname) : null;
+                dbname = isBlank(dbname) ? null : decrypter.decrypt(XCC_DBNAME, dbname);
             }
             for (String host: StringUtils.commaSeparatedValuesToList(hostnames)) {
                 if (decrypter != null) {
                     host = decrypter.decrypt(XCC_HOSTNAME, host);
                 }
                 String connectionUri = StringUtils.getXccUri(protocol, username, password, host, port, dbname);
-                if (connectionUri != null) {
-                    connectionUriList.add(connectionUri);
-                }
+                connectionUriList.add(connectionUri);
             }
         } else {
             for (String connectionUri : StringUtils.commaSeparatedValuesToList(uriAsStrings)) {
@@ -331,12 +329,12 @@ public abstract class AbstractManager {
                     username = decrypter.decrypt(XCC_USERNAME, username);
                     password = decrypter.decrypt(XCC_PASSWORD, password);
                     host = decrypter.decrypt(XCC_HOSTNAME, host);
-                    dbname = !isBlank(dbname) ? decrypter.decrypt(XCC_DBNAME, dbname) : null;
+                    dbname = isBlank(dbname) ? null : decrypter.decrypt(XCC_DBNAME, dbname);
                     uriAfterDecrypt = StringUtils.getXccUri(protocol, username, password, host, port, dbname);
                 }
             }
         } catch (IllegalStateException exc) {
-           LOG.log(WARNING,"Unable to parse connection uri "+ exc.getMessage());
+           LOG.log(WARNING,"Unable to parse connection URI "+ exc.getMessage());
         }
         return uriAfterDecrypt;
     }

--- a/src/test/java/com/marklogic/developer/corb/AbstractManagerTest.java
+++ b/src/test/java/com/marklogic/developer/corb/AbstractManagerTest.java
@@ -74,6 +74,9 @@ public class AbstractManagerTest {
     private static final String PASSWORD = "password";
     private static final String HOST = "localhost";
     private static final String PORT = "80";
+    
+    public static final String JASYPT_ALGORITHM = "jasypt.algorithm";
+    public static final String JASYPT_PASSWORD = "jasypt.password";
 
     private static final PrintStream ERROR = System.err;
 
@@ -399,6 +402,91 @@ public class AbstractManagerTest {
             LOG.log(Level.SEVERE, null, ex);
         }
         fail();
+    }
+    
+    @Test
+    public void testTryToDecryptUriInPartsClearText() {
+        AbstractManager instance = new AbstractManagerImpl();
+        instance.properties.setProperty(Options.DECRYPTER, JasyptDecrypter.class.getName());
+        instance.properties.setProperty(Options.JASYPT_PROPERTIES_FILE, "src/test/resources/jasypt.properties");
+        try {
+            instance.initDecrypter();
+        } catch (CorbException ex) {
+            LOG.log(Level.SEVERE, null, ex);
+            fail();
+        }
+        String origUri = "xcc://user:pass123@somehost:8000/FFE";
+        String expectedUri = "xcc://user:pass123@somehost:8000/FFE";
+        String newUri = instance.tryToDecryptUriInParts(origUri);
+        assertEquals(expectedUri,newUri);
+    }
+    
+    @Test
+    public void testTryToDecryptUriInPartsClearTextWithEncoding() {
+        AbstractManager instance = new AbstractManagerImpl();
+        instance.properties.setProperty(Options.DECRYPTER, JasyptDecrypter.class.getName());
+        instance.properties.setProperty(Options.JASYPT_PROPERTIES_FILE, "src/test/resources/jasypt.properties");
+        try {
+            instance.initDecrypter();
+        } catch (CorbException ex) {
+            LOG.log(Level.SEVERE, null, ex);
+            fail();
+        }
+        String origUri = "xcc://user:pass#123@somehost:8000/FFE";
+        String expectedUri = "xcc://user:pass%23123@somehost:8000/FFE";
+        String newUri = instance.tryToDecryptUriInParts(origUri);
+        assertEquals(expectedUri,newUri);
+    }
+    
+    @Test
+    public void testTryToDecryptUriInPartsPasswordEncrypted() {
+        AbstractManager instance = new AbstractManagerImpl();
+        instance.properties.setProperty(Options.DECRYPTER, JasyptDecrypter.class.getName());
+        instance.properties.setProperty(Options.JASYPT_PROPERTIES_FILE, "src/test/resources/jasypt.properties");
+        try {
+            instance.initDecrypter();
+        } catch (CorbException ex) {
+            LOG.log(Level.SEVERE, null, ex);
+            fail();
+        }
+        String origUri = "xcc://user:zSSKlCXLWCaZp/LrbX0k0juz6+D5sUbr@somehost:8000/FFE";
+        String expectedUri = "xcc://user:pass%23123@somehost:8000/FFE";
+        String newUri = instance.tryToDecryptUriInParts(origUri);
+        assertEquals(expectedUri,newUri);
+    }
+    
+    @Test
+    public void testTryToDecryptUriInPartsPasswordEnocoded() {
+        AbstractManager instance = new AbstractManagerImpl();
+        instance.properties.setProperty(Options.DECRYPTER, JasyptDecrypter.class.getName());
+        instance.properties.setProperty(Options.JASYPT_PROPERTIES_FILE, "src/test/resources/jasypt.properties");
+        try {
+            instance.initDecrypter();
+        } catch (CorbException ex) {
+            LOG.log(Level.SEVERE, null, ex);
+            fail();
+        }
+        String origUri = "xcc://user:ENC(TThPQnCGGMjO7soUk/Kb8o1DQE7kUOVW)@somehost:8000/FFE";
+        String expectedUri = "xcc://user:pass%23123@somehost:8000/FFE";
+        String newUri = instance.tryToDecryptUriInParts(origUri);
+        assertEquals(expectedUri,newUri);
+    }
+    
+    @Test
+    public void testTryToDecryptUriInPartsMultiPartEncryption() {
+        AbstractManager instance = new AbstractManagerImpl();
+        instance.properties.setProperty(Options.DECRYPTER, JasyptDecrypter.class.getName());
+        instance.properties.setProperty(Options.JASYPT_PROPERTIES_FILE, "src/test/resources/jasypt.properties");
+        try {
+            instance.initDecrypter();
+        } catch (CorbException ex) {
+            LOG.log(Level.SEVERE, null, ex);
+            fail();
+        }
+        String origUri = "xcc://ENC(v5b+VYiO4qpoZmVGkWieDg==):TThPQnCGGMjO7soUk/Kb8o1DQE7kUOVW@e+nz4XEN9SuuazGnbr6Ec5cyid1/l0qn:8000";
+        String expectedUri = "xcc://user:pass%23123@somehost:8000";
+        String newUri = instance.tryToDecryptUriInParts(origUri);
+        assertEquals(expectedUri,newUri);
     }
 
     @Test

--- a/src/test/resources/jasypt.properties
+++ b/src/test/resources/jasypt.properties
@@ -1,5 +1,5 @@
 # Jasypt properties
 # Encryption/Decryption algorithm.
-# Optional. Default is PBEWITHMD5ANDDES
-#jasypt.algorithm=PBEWithMD5AndTripleDES
+# Optional. Default is PBEWithMD5AndTripleDES
+jasypt.algorithm=PBEWITHMD5ANDDES
 jasypt.password=corbencrypt


### PR DESCRIPTION
[Issue-123] Supporting encryption of password, username, hostname or dbname fields of the connection string. This should enable customers to keep the existing connection string, but only encrypt the password field. Also, encrypted portion can be optionally enclosed with in ENC(). Added additional test cases to AbstractManagerTest to test this new feature. I have also done some manual testing of various use cases.  