### PR TITLE
Ensure that options with empty string values are returned

### DIFF
--- a/src/main/java/com/marklogic/developer/corb/AbstractManager.java
+++ b/src/main/java/com/marklogic/developer/corb/AbstractManager.java
@@ -480,11 +480,14 @@ public abstract class AbstractManager {
      * @return the trimmed property value
      */
     protected String getOption(String argVal, String propertyName) {
-        String retVal;
+        String retVal = null;
         if (isNotBlank(argVal)) {
             retVal = argVal.trim();
         } else {
-            retVal = Options.findOption(properties, propertyName);
+            String property = Options.findOption(properties, propertyName);
+            if (isNotBlank(property)) {
+                retVal = property;
+            }
         }
         //doesn't capture defaults, only user provided.
         String[] secureWords = {"XCC", "PASSWORD", "SSL"};

--- a/src/main/java/com/marklogic/developer/corb/AbstractTask.java
+++ b/src/main/java/com/marklogic/developer/corb/AbstractTask.java
@@ -32,8 +32,8 @@ import static com.marklogic.developer.corb.TransformOptions.FAILED_URI_TOKEN;
 import com.marklogic.developer.corb.util.StringUtils;
 import static com.marklogic.developer.corb.util.StringUtils.commaSeparatedValuesToList;
 import static com.marklogic.developer.corb.util.StringUtils.isEmpty;
+import static com.marklogic.developer.corb.util.StringUtils.isNotBlank;
 import static com.marklogic.developer.corb.util.StringUtils.isNotEmpty;
-import static com.marklogic.developer.corb.util.StringUtils.trim;
 import com.marklogic.xcc.Request;
 import com.marklogic.xcc.RequestOptions;
 import com.marklogic.xcc.ResultSequence;
@@ -220,7 +220,7 @@ public abstract class AbstractTask implements Task {
         }
 
         RequestOptions requestOptions = request.getOptions();
-        if (language != null) {
+        if (isNotBlank(language)) {
             requestOptions.setQueryLanguage(language);
         }
         if (timeZone != null) {

--- a/src/main/java/com/marklogic/developer/corb/Options.java
+++ b/src/main/java/com/marklogic/developer/corb/Options.java
@@ -1301,9 +1301,9 @@ public final class Options {
             final String snakeCase = propertyName.replace("-", "_");
             final String kebabCase = propertyName.replace("_", "-");
             for (String key : Arrays.asList(propertyName, snakeCase, kebabCase)) {
-                if (isNotBlank(System.getProperty(key))) {
+                if (System.getProperty(key) != null) {
                     return System.getProperty(key).trim();
-                } else if (properties.containsKey(key) && isNotBlank(properties.getProperty(key))) {
+                } else if (properties.containsKey(key) && properties.getProperty(key) != null) {
                     return properties.getProperty(key).trim();
                 }
             }

--- a/src/main/java/com/marklogic/developer/corb/TaskFactory.java
+++ b/src/main/java/com/marklogic/developer/corb/TaskFactory.java
@@ -31,6 +31,8 @@ import static com.marklogic.developer.corb.util.StringUtils.isEmpty;
 import static com.marklogic.developer.corb.util.StringUtils.isInlineModule;
 import static com.marklogic.developer.corb.util.StringUtils.isInlineOrAdhoc;
 import static com.marklogic.developer.corb.util.StringUtils.isJavaScriptModule;
+import static com.marklogic.developer.corb.util.StringUtils.isNotBlank;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -173,7 +175,7 @@ public class TaskFactory {
         task.setProperties(managerProperties);
 
         String timeZoneId = Options.findOption(managerProperties, XCC_TIME_ZONE);
-        if (timeZoneId != null) {
+        if (isNotBlank(timeZoneId)) {
             TimeZone timeZone = TimeZone.getTimeZone(timeZoneId);
             task.setTimeZone(timeZone);
         }

--- a/src/test/java/com/marklogic/developer/corb/OptionsTest.java
+++ b/src/test/java/com/marklogic/developer/corb/OptionsTest.java
@@ -64,6 +64,15 @@ public class OptionsTest {
     }
 
     @Test
+    public void testFindOptionWithEmptyStringValue() {
+        String key = "foo";
+        String value = "";
+        Properties properties = new Properties();
+        properties.setProperty(key, value);
+        assertEquals(value, Options.findOption(properties, "foo"));
+    }
+
+    @Test
     public void testFindOptionMissing() {
         Properties properties = new Properties();
         assertNull(Options.findOption(properties, "foo"));


### PR DESCRIPTION
Options with empty string values were being filtered out. Some customers were relying on these keys with empty string variables, and caused existing jobs to fail.