### PR TITLE
Change Slow Receive message to reference -XX:+UseG1GC

### DIFF
--- a/src/main/java/com/marklogic/developer/corb/QueryUrisLoader.java
+++ b/src/main/java/com/marklogic/developer/corb/QueryUrisLoader.java
@@ -321,7 +321,7 @@ public class QueryUrisLoader extends AbstractUrisLoader {
 
         boolean slowReceive = System.currentTimeMillis() - lastMessageMillis > (1000 * 4);
         if (slowReceive) {
-            LOG.log(WARNING, () -> "Slow receive! Consider increasing max heap size and using -XX:+UseConcMarkSweepGC");
+            LOG.log(WARNING, () -> "Slow receive! Consider increasing max heap size and using -XX:+UseG1GC, or using DISK-QUEUE option to limit memory demands.");
         }
 
         double megabytes = 1024d * 1024d;

--- a/src/test/java/com/marklogic/developer/corb/ManagerTest.java
+++ b/src/test/java/com/marklogic/developer/corb/ManagerTest.java
@@ -89,7 +89,6 @@ public class ManagerTest {
     public static final String POST_BATCH_XQUERY_MODULE_FOO = "post-bar";
     public static final String PRE_BATCH_XQUERY_MODULE_FOO = "pre-bar";
     public static final String PROCESS_MODULE = "src/test/resources/transform2.xqy|ADHOC";
-    public static final String SLOW_RECEIVE_MESSAGE = "Slow receive! Consider increasing max heap size and using -XX:+UseConcMarkSweepGC";
 
     private void clearSystemProperties() {
     		TestUtils.clearSystemProperties();


### PR DESCRIPTION
 instead of deprecated UseConcMarkSweepGC. Also added a note to consider applying DISK-QUEUE to limit memory demands.

Resolves issue #173