### PR TITLE
Remove JAXB dependency to make Java upgrades and compatibility easier

### DIFF
--- a/src/main/java/com/marklogic/developer/corb/HostKeyDecrypter.java
+++ b/src/main/java/com/marklogic/developer/corb/HostKeyDecrypter.java
@@ -19,6 +19,9 @@
 package com.marklogic.developer.corb;
 
 import com.marklogic.developer.corb.util.StringUtils;
+
+import static com.marklogic.developer.corb.util.StringUtils.byteArrayToHexString;
+import static com.marklogic.developer.corb.util.StringUtils.hexStringToByteArray;
 import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.WARNING;
 
@@ -50,7 +53,6 @@ import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 /**
  * Class that uses a private key associate with a particular host Key is
@@ -328,8 +330,7 @@ public class HostKeyDecrypter extends AbstractDecrypter {
         // encrypting with private key and random for initialization vector
         cipher.init(Cipher.ENCRYPT_MODE, key, new SecureRandom());
         byte[] encryptedVal = cipher.doFinal(plaintext.getBytes());
-        // base64 encode before returning
-        return DatatypeConverter.printHexBinary(encryptedVal);
+        return byteArrayToHexString(encryptedVal);
     }
 
     /**
@@ -342,8 +343,8 @@ public class HostKeyDecrypter extends AbstractDecrypter {
      * @throws NoSuchAlgorithmException
      * @throws InvalidKeyException
      */
-    private static String decrypt(String encryptedText) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException {
-        byte[] encryptedTextBytes = DatatypeConverter.parseHexBinary(encryptedText);
+    protected static String decrypt(String encryptedText) throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException {
+        byte[] encryptedTextBytes = hexStringToByteArray(encryptedText);
         SecretKeySpec secretSpec = new SecretKeySpec(privateKey, AES);
         Cipher cipher = Cipher.getInstance(AES);
         cipher.init(Cipher.DECRYPT_MODE, secretSpec, new SecureRandom());

--- a/src/main/java/com/marklogic/developer/corb/PrivateKeyDecrypter.java
+++ b/src/main/java/com/marklogic/developer/corb/PrivateKeyDecrypter.java
@@ -42,12 +42,13 @@ import java.security.spec.X509EncodedKeySpec;
 import java.text.MessageFormat;
 import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.SEVERE;
+
+import java.util.Base64;
 import java.util.logging.Logger;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
-import javax.xml.bind.DatatypeConverter;
 
 public class PrivateKeyDecrypter extends AbstractDecrypter {
 
@@ -117,7 +118,7 @@ public class PrivateKeyDecrypter extends AbstractDecrypter {
                     // remove the begin and end key lines if present.
                     keyAsString = keyAsString.replaceAll("[-]+(BEGIN|END)[A-Z ]*KEY[-]+", "");
 
-                    privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(DatatypeConverter.parseBase64Binary(keyAsString)));
+                    privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder().decode(keyAsString)));
                 }
                 LOG.log(INFO, "Initialized PrivateKeyDecrypter");
             } catch (Exception exc) {
@@ -151,7 +152,7 @@ public class PrivateKeyDecrypter extends AbstractDecrypter {
             try {
                 final Cipher cipher = Cipher.getInstance(algorithm);
                 cipher.init(Cipher.DECRYPT_MODE, privateKey);
-                dValue = new String(cipher.doFinal(DatatypeConverter.parseBase64Binary(value)));
+                dValue = new String(cipher.doFinal(Base64.getDecoder().decode(value)));
             } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | IllegalBlockSizeException | BadPaddingException exc) {
                 LOG.log(INFO, MessageFormat.format("Cannot decrypt {0}. Ignore if clear text.", property), exc);
             }
@@ -221,7 +222,7 @@ public class PrivateKeyDecrypter extends AbstractDecrypter {
             X509EncodedKeySpec x509EncodedKeySpec = new X509EncodedKeySpec(toByteArray(fis));
             Cipher cipher = Cipher.getInstance(algorithm);
             cipher.init(Cipher.ENCRYPT_MODE, KeyFactory.getInstance(algorithm).generatePublic(x509EncodedKeySpec));
-            String encryptedText = DatatypeConverter.printBase64Binary(cipher.doFinal(clearText.getBytes("UTF-8")));
+            String encryptedText = Base64.getEncoder().encodeToString(cipher.doFinal(clearText.getBytes("UTF-8")));
             System.out.println("Input: " + clearText + "\nOutput: " + encryptedText); // NOPMD
         }
     }

--- a/src/main/java/com/marklogic/developer/corb/util/StringUtils.java
+++ b/src/main/java/com/marklogic/developer/corb/util/StringUtils.java
@@ -72,6 +72,34 @@ public final class StringUtils {
     }
 
     /**
+     * Convert a byte array into a string of the hex encoded values
+     * @param bytes
+     * @return
+     */
+    public static String byteArrayToHexString(byte[] bytes) {
+        StringBuilder hexStringBuilder = new StringBuilder(bytes.length * 2);
+        for (byte b: bytes) {
+            hexStringBuilder.append(String.format("%02x", b));
+        }
+        return hexStringBuilder.toString();
+    }
+
+    /**
+     * Convert the hex string into an array of bytes
+     * @param hexString
+     * @return
+     */
+    public static byte[] hexStringToByteArray(String hexString) {
+        int len = hexString.length();
+        byte[] result = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            result[i / 2] = (byte) ((Character.digit(hexString.charAt(i), 16) << 4)
+                + Character.digit(hexString.charAt(i+1), 16));
+        }
+        return result;
+    }
+
+    /**
      * Joins items of the provided collection into a single String using the
      * delimiter specified.
      *

--- a/src/test/java/com/marklogic/developer/corb/util/StringUtilsTest.java
+++ b/src/test/java/com/marklogic/developer/corb/util/StringUtilsTest.java
@@ -19,6 +19,7 @@
 package com.marklogic.developer.corb.util;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -452,4 +453,28 @@ public class StringUtilsTest {
         assertFalse(StringUtils.isUrlEncoded("this that"));
         assertFalse(StringUtils.isUrlEncoded("my milk is 2%"));
     }
+
+    @Test
+    public void testRoundTripByteArrayToHexStringAndHexStringToByteArray() {
+        String input = "hello world";
+        String hex = StringUtils.byteArrayToHexString(input.getBytes(StandardCharsets.UTF_8));
+        byte[] bytes = StringUtils.hexStringToByteArray(hex);
+        String output = new String(bytes, StandardCharsets.UTF_8);
+        assertTrue(input.equals(output));
+    }
+
+    @Test
+    public void testByteArrayToHexString() {
+        String input = "xyz";
+        String hex = StringUtils.byteArrayToHexString(input.getBytes(StandardCharsets.UTF_8));
+        assertTrue("78797a".equals(hex));
+    }
+
+    @Test
+    public void testHexStringToByteArray() {
+        byte[] bytes = StringUtils.hexStringToByteArray("70617373776F7264");
+        byte[] expected = "password".getBytes(StandardCharsets.UTF_8);
+        assertTrue(Arrays.equals(expected, bytes));
+    }
+
 }


### PR DESCRIPTION
Replace hex conversion functions with local methods and Base64 conversion using java.util.Base64 to remove the JAXB dependency and make JAva upgrades and compatibility easier.