### PR TITLE
Auto-configure TwoWaySSL 

### DIFF
--- a/src/main/java/com/marklogic/developer/corb/AbstractManager.java
+++ b/src/main/java/com/marklogic/developer/corb/AbstractManager.java
@@ -18,16 +18,7 @@
  */
 package com.marklogic.developer.corb;
 
-import static com.marklogic.developer.corb.Options.DECRYPTER;
-import static com.marklogic.developer.corb.Options.OPTIONS_FILE;
-import static com.marklogic.developer.corb.Options.SSL_CONFIG_CLASS;
-import static com.marklogic.developer.corb.Options.XCC_CONNECTION_URI;
-import static com.marklogic.developer.corb.Options.XCC_DBNAME;
-import static com.marklogic.developer.corb.Options.XCC_HOSTNAME;
-import static com.marklogic.developer.corb.Options.XCC_PASSWORD;
-import static com.marklogic.developer.corb.Options.XCC_PORT;
-import static com.marklogic.developer.corb.Options.XCC_USERNAME;
-import static com.marklogic.developer.corb.Options.XCC_PROTOCOL;
+import static com.marklogic.developer.corb.Options.*;
 import static com.marklogic.developer.corb.util.IOUtils.isDirectory;
 
 import com.marklogic.developer.corb.util.NumberUtils;
@@ -251,6 +242,12 @@ public abstract class AbstractManager {
 
     protected void initSSLConfig() throws CorbException {
         String sslConfigClassName = getOption(SSL_CONFIG_CLASS);
+        //If the keystore options are set, but the sslConfigClassName wasn't configured, assume that they wanted the TwoWaySSLConfig class configured
+        if (getOption(SSL_KEYSTORE) != null &&
+            (getOption(SSL_KEYSTORE_PASSWORD) !=null || getOption(SSL_KEY_PASSWORD) !=null) &&
+            sslConfigClassName == null) {
+            sslConfigClassName = TwoWaySSLConfig.class.getCanonicalName();
+        }
         if (sslConfigClassName != null) {
             try {
                 Class<?> decrypterCls = Class.forName(sslConfigClassName);

--- a/src/test/java/com/marklogic/developer/corb/AbstractManagerTest.java
+++ b/src/test/java/com/marklogic/developer/corb/AbstractManagerTest.java
@@ -974,6 +974,60 @@ public class AbstractManagerTest {
         }
     }
 
+    @Test
+    public void testTwoWaySSLConfigAutoConfig() {
+        AbstractManager manager = new AbstractManagerImpl();
+        Properties properties = new Properties();
+        manager.properties.setProperty(Options.SSL_KEYSTORE, "publicKey.pem");
+        manager.properties.setProperty(Options.SSL_KEYSTORE_PASSWORD, "password");
+        try {
+            manager.initSSLConfig();
+            assertEquals("Since both keystore and keystore password configured, and no explicit ",
+                TwoWaySSLConfig.class, manager.sslConfig.getClass());
+        } catch (CorbException ex){
+            fail();
+        }
+    }
+    @Test
+    public void testTwoWaySSLConfigAutoConfigWithSSLKEYPASSWORD() {
+        AbstractManager manager = new AbstractManagerImpl();
+        manager.properties.setProperty(Options.SSL_KEYSTORE, "publicKey.pem");
+        manager.properties.setProperty(Options.SSL_KEY_PASSWORD, "password");
+        try {
+            manager.initSSLConfig();
+            assertEquals("Since both keystore and keystore password configured, and no explicit ",
+                TwoWaySSLConfig.class, manager.sslConfig.getClass());
+        } catch (CorbException ex){
+            fail();
+        }
+    }
+    @Test
+    public void testTwoWaySSLConfigAutoConfigNotSet() {
+        AbstractManager manager = new AbstractManagerImpl();
+        manager.properties.setProperty(Options.SSL_KEYSTORE, "publicKey.pem");
+        try {
+            manager.initSSLConfig();
+            assertEquals("Since no password configured, TwoWaySSLConfig not auto-configured",
+                TrustAnyoneSSLConfig.class, manager.sslConfig.getClass());
+        } catch (CorbException ex){
+            fail();
+        }
+    }
+    @Test
+    public void testTwoWaySSLConfigAutoConfigNotOverridingExplicitConfig() {
+        AbstractManager manager = new AbstractManagerImpl();
+        manager.properties.setProperty(Options.SSL_KEYSTORE, "publicKey.pem");
+        manager.properties.setProperty(Options.SSL_KEYSTORE_PASSWORD, "password");
+        manager.properties.setProperty(Options.SSL_CONFIG_CLASS, TrustAnyoneSSLConfig.class.getCanonicalName());
+        try {
+            manager.initSSLConfig();
+            assertEquals("Since SSL-CONFIG-CLASS explicitly configured, don't auto-configure TwoWaySSLConfig",
+                TrustAnyoneSSLConfig.class, manager.sslConfig.getClass());
+        } catch (CorbException ex){
+            fail();
+        }
+    }
+
     public static class TestContentSourcePool extends DefaultContentSourcePool { }
 
     public static class AbstractManagerImpl extends AbstractManager {


### PR DESCRIPTION
if both the SSL-KEYSTORE and SSL-KEYSTORE-PASSWORD are set and there isn't an SSL-CONFIG-CLASS explicitly set.

Resolves issue #202 