### PR TITLE
Expose execError with hasExecError() method

### DIFF
--- a/src/main/java/com/marklogic/developer/corb/Manager.java
+++ b/src/main/java/com/marklogic/developer/corb/Manager.java
@@ -170,11 +170,15 @@ public class Manager extends AbstractManager implements Closeable {
         return exitCode;
     }
 
+    public boolean hasExecError() {
+        return execError;
+    }
+
     protected void setExitCode(int code) {
         exitCode = code;
     }
 
-    protected int getExitCode() {
+    public int getExitCode() {
         return determineExitCode();
     }
 


### PR DESCRIPTION
and change visibility of getExitCode() to public.

Resolves issue #216 