### PR TITLE
Usage improvement

### DIFF
--- a/src/main/java/com/marklogic/developer/corb/AbstractManager.java
+++ b/src/main/java/com/marklogic/developer/corb/AbstractManager.java
@@ -44,12 +44,9 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.Field;
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
+
 import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.WARNING;
 import static java.util.logging.Level.SEVERE;
@@ -156,6 +153,18 @@ public abstract class AbstractManager {
 
     public TransformOptions getOptions() {
         return options;
+    }
+
+    public static boolean hasUsage(String... args) {
+        return args != null &&
+            Arrays.stream(args).anyMatch(arg ->
+                "-h".equalsIgnoreCase(arg) ||
+                "--help".equalsIgnoreCase(arg) ||
+                "--usage".equalsIgnoreCase(arg));
+    }
+
+    public static String getHelpFlagMessage() {
+        return "For a full list of options and usage information, use commandline switch -h or --help or --usage";
     }
 
     public void initProperties(Properties props) throws CorbException {
@@ -511,7 +520,7 @@ public abstract class AbstractManager {
                 + "If specified in more than one place, a command line parameter takes precedence over "
                 + "a Java system property, which take precedence over a property "
                 + "from the OPTIONS-FILE properties file.\n\n"
-                + "CoRB2 Options:\n"); // NOPMD
+                + "CoRB Options:\n"); // NOPMD
 
         for (java.lang.reflect.Field field : Options.class.getDeclaredFields()) {
             Usage usage = field.getAnnotation(Usage.class);

--- a/src/main/java/com/marklogic/developer/corb/Manager.java
+++ b/src/main/java/com/marklogic/developer/corb/Manager.java
@@ -127,14 +127,14 @@ public class Manager extends AbstractManager implements Closeable {
      */
     public static void main(String... args) {
         try (Manager manager = new Manager()) {
-            if (args != null && Arrays.stream(args).anyMatch(arg -> "-?".equalsIgnoreCase(arg) || "-h".equalsIgnoreCase(arg) || "--help".equalsIgnoreCase(arg) || "--usage".equalsIgnoreCase(arg))) {
+            if (hasUsage(args)) {
                 manager.usage();
             } else {
                 try {
                     manager.init(args);
                 } catch (Exception exc) {
-                    manager.usage();
                     LOG.log(SEVERE, "Error initializing CoRB " + exc.getMessage(), exc);
+                    LOG.log(INFO, getHelpFlagMessage());
                     LOG.log(INFO, () -> "init error - exiting with code " + EXIT_CODE_INIT_ERROR);
                     System.exit(EXIT_CODE_INIT_ERROR);
                 }
@@ -552,16 +552,16 @@ public class Manager extends AbstractManager implements Closeable {
         super.usage();
 
         List<String> args = new ArrayList<>(7);
-        String xccConnectionUri = "xcc://user:password@host:port/[ database ]";
+        String xccConnectionUri = "xcc://user:password@host:port/[database]";
         String threadCount = "10";
         String optionsFile = "myjob.properties";
         PrintStream err = System.err; // NOPMD
 
         err.println("usage 1:"); // NOPMD
         err.println(TAB + NAME + ' ' + xccConnectionUri + " input-selector module-name.xqy"
-                + " [ thread-count [ uris-module [ module-root" + " [ modules-database [ install [ process-task"
-                + " [ pre-batch-module [ pre-batch-task" + " [ post-batch-module  [ post-batch-task"
-                + " [ export-file-dir [ export-file-name" + " [ uris-file ] ] ] ] ] ] ] ] ] ] ] ] ]"); // NOPMD
+                + " [THREAD-COUNT] [URIS-MODULE] [MODULE-ROOT] [MODULES-DATABASE] [INSTALL] [PROCESS-TASK]"
+                + " [PRE-BATCH-MODULE] [PRE-BATCH-TASK] [POST-BATCH-MODULE] [POST-BATCH-TASK]"
+                + " [EXPORT-FILE-DIR] [EXPORT-FILE-NAME] [URIS-FILE]"); // NOPMD
 
         err.println("\nusage 2:");
         args.add(buildSystemPropertyArg(XCC_CONNECTION_URI, xccConnectionUri));

--- a/src/main/java/com/marklogic/developer/corb/ModuleExecutor.java
+++ b/src/main/java/com/marklogic/developer/corb/ModuleExecutor.java
@@ -74,23 +74,27 @@ public class ModuleExecutor extends AbstractManager {
      */
     public static void main(String... args) {
         ModuleExecutor moduleExecutor = new ModuleExecutor();
-        try {
-            moduleExecutor.init(args);
-        } catch (Exception exc) {
-            LOG.log(SEVERE, "Error initializing ModuleExecutor", exc);
+        if (hasUsage(args)) {
             moduleExecutor.usage();
-            LOG.log(INFO, () -> "init error - exiting with code " + EXIT_CODE_INIT_ERROR);
-            System.exit(EXIT_CODE_INIT_ERROR);
-        }
+        } else {
+            try {
+                moduleExecutor.init(args);
+            } catch (Exception exc) {
+                LOG.log(SEVERE, "Error initializing ModuleExecutor", exc);
+                LOG.log(INFO, getHelpFlagMessage());
+                LOG.log(INFO, () -> "init error - exiting with code " + EXIT_CODE_INIT_ERROR);
+                System.exit(EXIT_CODE_INIT_ERROR);
+            }
 
-        try {
-            moduleExecutor.run();
-            LOG.log(INFO, () -> "success - exiting with code " + EXIT_CODE_SUCCESS);
-            System.exit(EXIT_CODE_SUCCESS);
-        } catch (Exception exc) {
-            LOG.log(SEVERE, "Error while running CORB", exc);
-            LOG.log(INFO, () -> "processing error - exiting with code " + EXIT_CODE_PROCESSING_ERROR);
-            System.exit(EXIT_CODE_PROCESSING_ERROR);
+            try {
+                moduleExecutor.run();
+                LOG.log(INFO, () -> "success - exiting with code " + EXIT_CODE_SUCCESS);
+                System.exit(EXIT_CODE_SUCCESS);
+            } catch (Exception exc) {
+                LOG.log(SEVERE, "Error while running CORB", exc);
+                LOG.log(INFO, () -> "processing error - exiting with code " + EXIT_CODE_PROCESSING_ERROR);
+                System.exit(EXIT_CODE_PROCESSING_ERROR);
+            }
         }
     }
 

--- a/src/test/java/com/marklogic/developer/corb/ManagerDemo.java
+++ b/src/test/java/com/marklogic/developer/corb/ManagerDemo.java
@@ -59,7 +59,7 @@ public class ManagerDemo {
         properties.setProperty(Options.METRICS_COLLECTIONS, "managerDemo");
 
         Manager manager = new Manager();
-
+        new File(exportFilename).deleteOnExit();
         try {
             manager.init(properties);
 


### PR DESCRIPTION
Returning the full usage info and all options is too much. It makes it difficult to find the exception and error message and causes users to scroll through a ton of text.

Change to not generate the full usage statement in an initi exception. Instead, inform the user of how they can request usage info by applying `-h` or `--help` or `--usage` switches.