### PR TITLE
Add OneWaySSLConfig class that uses default cacerts TrustStore 

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,12 @@ Option | Description
 **<a name="XCC-CONNECTION-RETRY-LIMIT"></a>XCC-CONNECTION-RETRY-LIMIT** | Number attempts to connect to ML before giving up. Default is `3`.
 **<a name="XCC-CONNECTION-RETRY-INTERVAL"></a>XCC-CONNECTION-RETRY-INTERVAL** | Time interval, in seconds, between retry attempts. Default is `60`.
 **<a name="XCC-CONNECTION-HOST-RETRY-LIMIT"></a>XCC-CONNECTION-HOST-RETRY-LIMIT** | Number attempts to connect to ML before giving up on a host. If not specified, it defaults to **XCC-CONNECTION-RETRY-LIMIT**
-**<a name="XCC-DBNAME"></a>XCC-DBNAME** | (Optional) Name of the content database to execute against
+**<a name="XCC-DBNAME"></a>XCC-DBNAME** | (optional) Name of the content database to execute against
 **<a name="XCC-HOSTNAME"></a>XCC-HOSTNAME** | Required if **XCC-CONNECTION-URI** is not specified. Multiple host can be specified with comma as a separator. 
 **<a name="XCC-HTTPCOMPLIANT"></a>XCC-HTTPCOMPLIANT** | Optional boolean flag to indicate whether to enable HTTP 1.1 compliance in XCC. If this option is set, the [`xcc.httpcompliant`](https://docs.marklogic.com/guide/xcc/concepts#id_28335) System property will be set. Default is `true`.
 **<a name="XCC-PASSWORD"></a>XCC-PASSWORD** | Required if **XCC-CONNECTION-URI** is not specified.
 **<a name="XCC-PORT"></a>XCC-PORT** | Required if **XCC-CONNECTION-URI** is not specified.
-**<a name="XCC-PROTOCOL"></a>XCC-PROTOCOL** | (Optional) Used if XCC-CONNECTION-URI is not specified. The XCC scheme to use; either `xcc` or `xccs`. Default is `xcc`.
+**<a name="XCC-PROTOCOL"></a>XCC-PROTOCOL** | (optional) Used if XCC-CONNECTION-URI is not specified. The XCC scheme to use; either `xcc` or `xccs`. Default is `xcc`.
 **<a name="XCC-TIME-ZONE"></a>XCC-TIME-ZONE** | The ID for the TimeZone that should be set on XCC RequestOption. When a value is specified, it is parsed using [`TimeZone.getTimeZone()`](https://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html#getTimeZone-java.lang.String-) and set on XCC RequestOption for each Task. Invalid ID values will produce the GMT TimeZone. If not specified, XCC uses the JVM default TimeZone.
 **<a name="XCC-URL-ENCODE-COMPONENTS"></a>XCC-URL-ENCODE-COMPONENTS** | Indicate whether or not the XCC connection string components should be URL encoded. Possible values are `always`, `never`, and `auto`. Default is `auto`.
 **<a name="XCC-USERNAME"></a>XCC-USERNAME** | Required if **XCC-CONNECTION-URI** is not specified.
@@ -214,8 +214,8 @@ Option | Description
 ---|---
 **<a name="DECRYPTER"></a>DECRYPTER** | Must implement `com.marklogic.developer.corb.Decrypter`. Encryptable options include **XCC-CONNECTION-URI**, **XCC-USERNAME**, **XCC-PASSWORD**, **XCC-HOSTNAME**, **XCC-PORT**, and **XCC-DBNAME** <ul><li>`com.marklogic.developer.corb.PrivateKeyDecrypter` (Included) Requires private key file</li><li>`com.marklogic.developer.corb.JasyptDecrypter` (Included) Requires jasypt-*.jar in classpath</li><li>`com.marklogic.developer.corb.HostKeyDecrypter` (Included) Requires Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files</li></ul>
 **<a name="PRIVATE-KEY-FILE"></a>PRIVATE-KEY-FILE**  | Required property for PrivateKeyDecrypter. This file should be accessible in the classpath or on the file system
-**<a name="PRIVATE-KEY-ALGORITHM"></a>PRIVATE-KEY-ALGORITHM** | (Optional) <ul><li>Default algorithm for PrivateKeyDecrypter is RSA.</li><li>Default algorithm for JasyptDecrypter is PBEWithMD5AndTripleDES</li><ul>
-**<a name="JASYPT-PROPERTIES-FILE"></a>JASYPT-PROPERTIES-FILE** | (Optional) Property file for the JasyptDecrypter. If not specified, it uses default `jasypt.proeprties` file, which should be accessible in the classpath or file system.
+**<a name="PRIVATE-KEY-ALGORITHM"></a>PRIVATE-KEY-ALGORITHM** | (optional) <ul><li>Default algorithm for PrivateKeyDecrypter is RSA.</li><li>Default algorithm for JasyptDecrypter is PBEWithMD5AndTripleDES</li><ul>
+**<a name="JASYPT-PROPERTIES-FILE"></a>JASYPT-PROPERTIES-FILE** | (optional) Property file for the JasyptDecrypter. If not specified, it uses default `jasypt.proeprties` file, which should be accessible in the classpath or file system.
 
 #### com.marklogic.developer.corb.PrivateKeyDecrypter
 PrivateKeyDecrypter automatically detects if the text is encrypted. Unencrypted text or clear text is returned as-is. Although not required, encrypted text can be optionally enclosed with "ENC" ex: ENC(xxxxxx) to clearly indicate that it is encrypted.  
@@ -266,27 +266,43 @@ To test if server is properly configured to use the HostKeyDecrypter:
 `java -cp /path/to/lib/* com.marklogic.developer.corb.HostKeyDecrypter test`  
 
 ### SSL Support
-CoRB provides support for SSL over XCC. As a prerequisite to enabling CoRB SSL support, the XDBC server must be configured to use SSL. It is necessary to specify **XCC-CONNECTION-URI** property with a protocol of 'xccs'. To configure a particular type of SSL configuration use the following property:
+CoRB provides support for SSL/TLS over XCCS. As a prerequisite to enabling CoRB SSL support, the XDBC server must be configured to use SSL. It is necessary to specify **XCC-CONNECTION-URI** property with a protocol of 'xccs'. To configure a particular type of SSL configuration use the following property:
 
 Option | Description
 ---|---
-**<a name="SSL-CONFIG-CLASS"></a>SSL-CONFIG-CLASS** | Must implement `com.marklogic.developer.corb.SSLConfig` <ul><li>`com.marklogic.developer.corb.TrustAnyoneSSLConfig` (Included)</li><li>`com.marklogic.developer.corb.TwoWaySSLConfig` (Included) supports 2-way SSL</li></ul>
+**<a name="SSL-CONFIG-CLASS"></a>SSL-CONFIG-CLASS** | Must implement `com.marklogic.developer.corb.SSLConfig`<ul><li>`com.marklogic.developer.corb.TrustAnyoneSSLConfig` (default)</li><li>`com.marklogic.developer.corb.OneWaySSLConfig`</li><li>`com.marklogic.developer.corb.TwoWaySSLConfig`</li></ul>
 
 #### com.marklogic.developer.corb.TrustAnyoneSSLConfig
-TrustAnyoneSSLConfig is the default implementation of the SSLContext. It will accept any certificate presented by the MarkLogic server.
+**TrustAnyoneSSLConfig** is the default implementation of the SSLContext. It will accept any certificate presented by the MarkLogic server.
 
-#### com.marklogic.developer.corb.TwoWaySSLConfig
-TwoWaySSLConfig is more complete and configurable implementation of the SSLContext. It supports SSL with mutual authentication. It is configurable via the following properties:
+#### com.marklogic.developer.corb.OneWaySSLConfig
+**OneWaySSLConfig** uses the default Java truststore for the SSLContext, but can be configured to use a custom TrustStore and (encryptable) password, instead of using the default cacerts.
 
 Option | Description
 ---|---
-**<a name="SSL-PROPERTIES-FILE"></a>SSL-PROPERTIES-FILE** | (Optional) A properties file that can be used to load a common SSL configuration.
-**<a name="SSL-KEYSTORE"></a>SSL-KEYSTORE** | Location of the keystore certificate.
-**<a name="SSL-KEYSTORE-PASSWORD"></a>SSL-KEYSTORE-PASSWORD** | (Encrytable) Password of the keystore file.
-**<a name="SSL-KEY-PASSWORD"></a>SSL-KEY-PASSWORD** | (Encryptable) Password of the private key.
-**<a name="SSL-KEYSTORE-TYPE"></a>SSL-KEYSTORE-TYPE** | Type of the keystore such as 'JKS' or 'PKCS12'.
-**<a name="SSL-ENABLED-PROTOCOLS"></a>SSL-ENABLED-PROTOCOLS** | (Optional) A comma or colon separated list of acceptable SSL protocols, in priority order. Default is `TLSv1.2`.
-**<a name="SSL-CIPHER-SUITES"></a>SSL-CIPHER-SUITES** | A comma or colon separated list of acceptable cipher suites used.
+**<a name="SSL-CIPHER-SUITES"></a>SSL-CIPHER-SUITES** | (optional) A comma or colon separated list of acceptable cipher suites used.
+**<a name="SSL-ENABLED-PROTOCOLS"></a>SSL-ENABLED-PROTOCOLS** | (optional) A comma or colon separated list of acceptable SSL protocols, in priority order. Default is `TLSv1.2`.
+**<a name="SSL-PROPERTIES-FILE"></a>SSL-PROPERTIES-FILE** | (optional) A properties file that can be used to load a common SSL configuration.
+**<a name="SSL-TRUSTSTORE"></a>SSL-TRUSTSTORE** | Location of the truststore file.
+**<a name="SSL-TRUSTSTORE-PASSWORD"></a>SSL-TRUSTSTORE-PASSWORD** | (encryptable) Password of the truststore file.
+**<a name="SSL-TRUSTSTORE-TYPE"></a>SSL-TRUSTSTORE-TYPE** | (optional) Type of the keystore, such as 'JKS' or 'PKCS12'.
+
+
+#### com.marklogic.developer.corb.TwoWaySSLConfig
+**TwoWaySSLConfig** is more complete and configurable implementation of the SSLContext. It supports SSL with mutual authentication. It is configurable via the following properties:
+
+Option | Description
+---|---
+**<a name="SSL-CIPHER-SUITES"></a>SSL-CIPHER-SUITES** | (optional) A comma or colon separated list of acceptable cipher suites used.
+**<a name="SSL-ENABLED-PROTOCOLS"></a>SSL-ENABLED-PROTOCOLS** | (optional) A comma or colon separated list of acceptable SSL protocols, in priority order. Default is `TLSv1.2`.
+**<a name="SSL-KEYSTORE"></a>SSL-KEYSTORE** | Location of the keystore file.
+**<a name="SSL-KEYSTORE-PASSWORD"></a>SSL-KEYSTORE-PASSWORD** | (encryptable) Password of the keystore file.
+**<a name="SSL-KEYSTORE-TYPE"></a>SSL-KEYSTORE-TYPE** | (optional) Type of the keystore, such as 'JKS' or 'PKCS12'.
+**<a name="SSL-KEY-PASSWORD"></a>SSL-KEY-PASSWORD** | (encryptable) Password of the private key.
+**<a name="SSL-PROPERTIES-FILE"></a>SSL-PROPERTIES-FILE** | (optional) A properties file that can be used to load a common SSL configuration.
+**<a name="SSL-TRUSTSTORE"></a>SSL-TRUSTSTORE** | Location of the truststore file.
+**<a name="SSL-TRUSTSTORE-PASSWORD"></a>SSL-TRUSTSTORE-PASSWORD** | (encryptable) Password of the truststore file.
+**<a name="SSL-TRUSTSTORE-TYPE"></a>SSL-TRUSTSTORE-TYPE** | (optional) Type of the keystore, such as 'JKS' or 'PKCS12'.
 
 ### Load Balancing and Failover with Multiple Hosts
 CoRB 2.4+ supports load balancing and failover using `com.marklogic.developer.corb.ContentSourcePool`. This is automatically enabled when multiple comma separated values (supports encryption) are specified for for **XCC-CONNECTION-URI** or **XCC-HOSTNAME**.

--- a/src/main/java/com/marklogic/developer/corb/OneWaySSLConfig.java
+++ b/src/main/java/com/marklogic/developer/corb/OneWaySSLConfig.java
@@ -1,0 +1,23 @@
+package com.marklogic.developer.corb;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Standard SSL/TLS with the option to configure a custom TrustStore
+ * @since 2.5.7
+ */
+public class OneWaySSLConfig extends AbstractSSLConfig {
+
+    @Override
+    public SSLContext getSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
+        loadPropertiesFile();
+        TrustManager[] trustManager = getTrustManagers();
+        SSLContext sslContext = getSSLContextInstance(getEnabledProtocols());
+        sslContext.init(null, trustManager, null);
+        return sslContext;
+    }
+
+}

--- a/src/main/java/com/marklogic/developer/corb/Options.java
+++ b/src/main/java/com/marklogic/developer/corb/Options.java
@@ -525,13 +525,13 @@ public final class Options {
     @Usage(description = "Specify which external variable to set when invoking the loader process module. Choices are URI or DOC. Default is URI.")
     public static final String LOADER_VARIABLE = "LOADER-VARIABLE";
     /**
-     * (Optional) Property file for the
+     * (optional) Property file for the
      * {@link com.marklogic.developer.corb.JasyptDecrypter}.
      * <p>
      * If not specified, it uses default jasypt.proeprties file, which should be
      * accessible in the classpath or file system.
      */
-    @Usage(description = "(Optional) Property file for the JasyptDecrypter. "
+    @Usage(description = "(optional) Property file for the JasyptDecrypter. "
             + "If not specified, it uses default jasypt.proeprties file, "
             + "which should be accessible in the classpath or file system.")
     public static final String JASYPT_PROPERTIES_FILE = "JASYPT-PROPERTIES-FILE";
@@ -839,7 +839,7 @@ public final class Options {
     public static final String PRE_POST_BATCH_ALWAYS_EXECUTE = "PRE-POST-BATCH-ALWAYS-EXECUTE";
 
     /**
-     * (Optional)
+     * (optional)
      * <ul>
      * <li>Default algorithm for PrivateKeyDecrypter is RSA.</li>
      * <li>Default algorithm for JasyptDecrypter is PBEWithMD5AndTripleDES</li>
@@ -849,7 +849,7 @@ public final class Options {
      * @see #DECRYPTER
      * @see #JASYPT_PROPERTIES_FILE
      */
-    @Usage(description = "(Optional)"
+    @Usage(description = "(optional)"
             + "Default algorithm for PrivateKeyDecrypter is RSA."
             + "Default algorithm for JasyptDecrypter is PBEWithMD5AndTripleDES")
     public static final String PRIVATE_KEY_ALGORITHM = "PRIVATE-KEY-ALGORITHM";
@@ -955,9 +955,9 @@ public final class Options {
     public static final String QUERY_RETRY_LIMIT = "QUERY-RETRY-LIMIT";
 
     /**
-     * A comma separated list of acceptable cipher suites used.
+     * (optional) A comma separated list of acceptable cipher suites used.
      */
-    @Usage(description = "A comma separated list of acceptable cipher suites used.")
+    @Usage(description = "(optional) A comma separated list of acceptable cipher suites used.")
     public static final String SSL_CIPHER_SUITES = "SSL-CIPHER-SUITES";
 
     /**
@@ -973,41 +973,62 @@ public final class Options {
     public static final String SSL_CONFIG_CLASS = "SSL-CONFIG-CLASS";
 
     /**
-     * (Optional) A comma separated list of acceptable SSL protocols
+     * (optional) A comma separated list of acceptable SSL protocols
      */
-    @Usage(description = "(Optional) A comma separated list of acceptable SSL protocols")
+    @Usage(description = "(optional) A comma separated list of acceptable SSL protocols")
     public static final String SSL_ENABLED_PROTOCOLS = "SSL-ENABLED-PROTOCOLS";
 
     /**
      * Location of the keystore certificate.
      */
-    @Usage(description = "Location of the keystore certificate.")
+    @Usage(description = "Location of the keystore file.")
     public static final String SSL_KEYSTORE = "SSL-KEYSTORE";
 
     /**
-     * (Encryptable) Password of the private key.
+     * (encryptable) Password of the private key.
      */
-    @Usage(description = "(Encryptable) Password of the private key.")
+    @Usage(description = "(encryptable) Password of the private key.")
     public static final String SSL_KEY_PASSWORD = "SSL-KEY-PASSWORD";
 
     /**
-     * (Encrytable) Password of the keystore file.
+     * (encryptable) Password of the keystore file.
      */
-    @Usage(description = "(Encrytable) Password of the keystore file.")
+    @Usage(description = "(encryptable) Password of the keystore file.")
     public static final String SSL_KEYSTORE_PASSWORD = "SSL-KEYSTORE-PASSWORD";
 
     /**
-     * Type of the keystore such as 'JKS' or 'PKCS12'.
+     * (optional) Type of the keystore, such as 'JKS' or 'PKCS12'.
      */
-    @Usage(description = "Type of the keystore such as 'JKS' or 'PKCS12'.")
+    @Usage(description = "Type of the keystore, such as 'JKS' or 'PKCS12'.")
     public static final String SSL_KEYSTORE_TYPE = "SSL-KEYSTORE-TYPE";
 
     /**
-     * (Optional) A properties file that can be used to load a common SSL
+     * (optional) A properties file that can be used to load a common SSL
      * configuration.
      */
-    @Usage(description = "(Optional) A properties file that can be used to load a common SSL configuration.")
+    @Usage(description = "(optional) A properties file that can be used to load a common SSL configuration.")
     public static final String SSL_PROPERTIES_FILE = "SSL-PROPERTIES-FILE";
+
+    /**
+     * (optional) Location of a custom truststore file.
+     * @since 2.5.7
+     */
+    @Usage(description = "(optional) Location of a custom truststore file.")
+    public static final String SSL_TRUSTSTORE = "SSL-TRUSTSTORE";
+
+    /**
+     * (encryptable) Password of the truststore file.
+     * @since 2.5.7
+     */
+    @Usage(description = "(encryptable) Password of the truststore file.")
+    public static final String SSL_TRUSTSTORE_PASSWORD = "SSL-TRUSTSTORE-PASSWORD";
+
+    /**
+     * (optional) Type of the truststore, such as 'JKS' or 'PKCS12'
+     * @since 2.5.7
+     */
+    @Usage(description = "(optional) Type of the truststore, such as 'JKS' or 'PKCS12'")
+    public static final String SSL_TRUSTSTORE_TYPE = "SSL-TRUSTSTORE-TYPE";
 
     /**
      * Path to a directory that can be used for temporary storage while processing records.
@@ -1169,9 +1190,9 @@ public final class Options {
     public static final String XCC_CONNECTION_URI = "XCC-CONNECTION-URI";
 
     /**
-     * (Optional) Name of the content database to execute against
+     * (optional) Name of the content database to execute against
      */
-    @Usage(description = "(Optional) Name of the content database to execute against")
+    @Usage(description = "(optional) Name of the content database to execute against")
     public static final String XCC_DBNAME = "XCC-DBNAME";
 
     /**

--- a/src/main/java/com/marklogic/developer/corb/TrustAnyoneSSLConfig.java
+++ b/src/main/java/com/marklogic/developer/corb/TrustAnyoneSSLConfig.java
@@ -18,12 +18,8 @@
  */
 package com.marklogic.developer.corb;
 
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.logging.Logger;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
@@ -33,23 +29,15 @@ import javax.net.ssl.X509TrustManager;
  *
  * @since 2.2.0
  */
-public class TrustAnyoneSSLConfig extends AbstractSSLConfig {
-
-    private static final Logger LOG = Logger.getLogger(TrustAnyoneSSLConfig.class.getName());
+public class TrustAnyoneSSLConfig extends OneWaySSLConfig {
 
     /**
-     * Returns an SSLContext, which <b>will not</b> perform any certificate chain validation. Use with caution!
-     *
-     * @return an SSLContext with a TrustManager that <b>will not</b> validate certificate chains.
-     * @throws NoSuchAlgorithmException
-     * @throws KeyManagementException
+     * Returns a custom TrustManager that will not perform any validation and will trust anyone.  Use with caution!
+     * @return
      */
     @Override
-    public SSLContext getSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
-        SSLContext sslContext = getSSLContextInstance(getEnabledProtocols());
-        TrustManager[] trust = new TrustManager[]{new TrustAnyoneManager()};
-        sslContext.init(null, trust, null);
-        return sslContext;
+    public TrustManager[] getTrustManagers() {
+        return new TrustManager[]{new TrustAnyoneManager()};
     }
 
     private static class TrustAnyoneManager implements X509TrustManager {

--- a/src/test/java/com/marklogic/developer/corb/ManagerIT.java
+++ b/src/test/java/com/marklogic/developer/corb/ManagerIT.java
@@ -18,10 +18,7 @@
  */
 package com.marklogic.developer.corb;
 
-import static com.marklogic.developer.corb.Options.EXPORT_FILE_NAME;
-import static com.marklogic.developer.corb.Options.PROCESS_MODULE;
-import static com.marklogic.developer.corb.Options.PROCESS_TASK;
-import static com.marklogic.developer.corb.Options.XCC_CONNECTION_URI;
+import static com.marklogic.developer.corb.Options.*;
 import static com.marklogic.developer.corb.TestUtils.clearFile;
 import static com.marklogic.developer.corb.TestUtils.containsLogRecord;
 import static com.marklogic.developer.corb.util.FileUtilsTest.getBytes;
@@ -97,8 +94,7 @@ public class ManagerIT {
 
     public boolean testManager(String[] args, File report) {
         boolean passed = false;
-        Manager manager = new Manager();
-        try {
+        try (Manager manager = new Manager()) {
             //First, verify the output using run()
             manager.init(args);
             manager.run();
@@ -129,13 +125,12 @@ public class ManagerIT {
     public void testInitOptionsSetNumTPSForETC() {
         Properties properties = ManagerTest.getDefaultProperties();
         properties.setProperty(Options.NUM_TPS_FOR_ETC, Integer.toString(500));
-        Manager manager = new Manager();
-        try {
+        try (Manager manager = new Manager()) {
             manager.init(properties);
+            assertEquals(500, manager.options.getNumTpsForETC());
         } catch (CorbException ex) {
             fail();
         }
-        assertEquals(500, manager.options.getNumTpsForETC());
     }
 
     @Test
@@ -146,7 +141,6 @@ public class ManagerIT {
 
     @Test
     public void testManagerUsingProgArgs() {
-
         clearSystemProperties();
         String exportFileName = "testManagerUsingProgArgs.txt";
         String exportFileDir = ManagerTest.EXPORT_FILE_DIR;
@@ -255,8 +249,7 @@ public class ManagerIT {
         properties.setProperty(Options.DISK_QUEUE_MAX_IN_MEMORY_SIZE, String.valueOf(10));
         properties.setProperty(Options.DISK_QUEUE_TEMP_DIR, "/var/tmp");
 
-        Manager manager = new Manager();
-        try {
+        try (Manager manager = new Manager()) {
             manager.init(properties);
             manager.run();
             File report = new File(ManagerTest.EXPORT_FILE_DIR + SLASH + exportFilename);
@@ -283,8 +276,7 @@ public class ManagerIT {
         properties.setProperty(EXPORT_FILE_NAME, exportFilename);
         properties.setProperty(Options.DISK_QUEUE_MAX_IN_MEMORY_SIZE, String.valueOf(10));
 
-        Manager manager = new Manager();
-        try {
+        try (Manager manager = new Manager() ) {
             manager.init(properties);
             manager.run();
             File report = new File(ManagerTest.EXPORT_FILE_DIR + SLASH + exportFilename);
@@ -389,8 +381,7 @@ public class ManagerIT {
         System.setProperty(Options.EXPORT_FILE_AS_ZIP, Boolean.toString(true));
         String[] args = {};
         //First, verify the output using run()
-        Manager manager = new Manager();
-        try {
+        try (Manager manager = new Manager()) {
             manager.init();
             manager.run();
 
@@ -462,8 +453,7 @@ public class ManagerIT {
         props.setProperty(XCC_CONNECTION_URI, ManagerTest.XCC_CONNECTION_URI);
         props.setProperty(PROCESS_MODULE, ManagerTest.PROCESS_MODULE);
         props.setProperty(EXPORT_FILE_NAME, filename);
-        Manager manager = new Manager();
-        try {
+        try (Manager manager = new Manager()) {
             manager.init(props);
             assertEquals(ExportBatchToFileTask.class.getName(), manager.getOption(PROCESS_TASK));
         } catch (CorbException ex){
@@ -516,8 +506,7 @@ public class ManagerIT {
         service.schedule(pause, 1, TimeUnit.SECONDS);
         service.schedule(resume, 5, TimeUnit.SECONDS);
 
-        Manager instance = new Manager();
-        try {
+        try (Manager instance = new Manager()) {
             instance.init();
             instance.run();
             int lineCount = FileUtils.getLineCount(exportFile);
@@ -573,8 +562,7 @@ public class ManagerIT {
         service.schedule(pause, 1, TimeUnit.SECONDS);
         service.schedule(resume, 4, TimeUnit.SECONDS);
 
-        Manager instance = new Manager();
-        try {
+        try (Manager instance = new Manager()) {
             instance.init();
             instance.run();
             int lineCount = FileUtils.getLineCount(exportFile);
@@ -663,8 +651,7 @@ public class ManagerIT {
             }
         };
 
-        Manager instance = new Manager();
-        try {
+        try (Manager instance = new Manager()) {
             instance.init();
 
             ScheduledExecutorService service = Executors.newScheduledThreadPool(1);

--- a/src/test/java/com/marklogic/developer/corb/OneWaySSLConfigTest.java
+++ b/src/test/java/com/marklogic/developer/corb/OneWaySSLConfigTest.java
@@ -1,0 +1,66 @@
+package com.marklogic.developer.corb;
+
+import com.marklogic.developer.corb.util.FileUtils;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.marklogic.developer.corb.Options.*;
+
+import static org.junit.Assert.*;
+
+public class OneWaySSLConfigTest {
+
+    private static final Logger LOG = Logger.getLogger(OneWaySSLConfigTest.class.getName());
+
+    @Test
+    public void getSSLContext() {
+        try {
+            SSLConfig instance = new OneWaySSLConfig();
+            SSLContext context = instance.getSSLContext();
+            assertNotNull(context);
+        } catch (NoSuchAlgorithmException | KeyManagementException ex) {
+            LOG.log(Level.SEVERE, null, ex);
+            fail();
+        }
+    }
+
+    @Test
+    public void testGetTrustManagers() {
+        OneWaySSLConfig instance = new OneWaySSLConfig();
+        Properties properties = new Properties();
+        properties.setProperty(SSL_TRUSTSTORE, FileUtils.getFile("keystore.jks").getAbsolutePath());
+
+        instance.setProperties(properties);
+        try {
+            TrustManager[] trustManagers = instance.getTrustManagers();
+            assertNotNull(trustManagers);
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testGetTrustManagersWrongType() {
+        OneWaySSLConfig instance = new OneWaySSLConfig();
+        Properties properties = new Properties();
+        properties.setProperty(SSL_TRUSTSTORE, FileUtils.getFile("keystore.jks").getAbsolutePath());
+        properties.setProperty(SSL_TRUSTSTORE_TYPE, "notjks");
+        instance.setProperties(properties);
+        TrustManager[] trustManagers = null;
+        try {
+            trustManagers = instance.getTrustManagers();
+            fail("should have had a problem with the truststore type");
+        } catch (Exception e) {
+
+        }
+        assertNull(trustManagers);
+    }
+
+}

--- a/src/test/java/com/marklogic/developer/corb/TrustAnyoneSSLConfigTest.java
+++ b/src/test/java/com/marklogic/developer/corb/TrustAnyoneSSLConfigTest.java
@@ -77,7 +77,6 @@ public class TrustAnyoneSSLConfigTest {
 
     @Test
     public void testGetEnabledProtocolsUsingJdkTlsClientProtocols() {
-        String originalTlsClientProtocols = System.getProperty("jdk.tls.client.protocols");
         System.setProperty("jdk.tls.client.protocols", "foo");
         TrustAnyoneSSLConfig instance = new TrustAnyoneSSLConfig();
         String[] result = instance.getEnabledProtocols();


### PR DESCRIPTION
Add an implementation to provide standard SSL/TLS using the default Java truststore and the option to configure a custom TrustStore.